### PR TITLE
Fix: height of canvas mirror element

### DIFF
--- a/apps/editor/components/editor.module.scss
+++ b/apps/editor/components/editor.module.scss
@@ -7,4 +7,13 @@
     list-style: decimal;
     list-style-position: inside;
   }
+
+  :global(.rsw-ce) {
+    height: fit-content;
+  }
+
+  :global(.rsw-toolbar) {
+    position: sticky;
+    top: 0;
+  }
 }

--- a/apps/editor/lib/dom.ts
+++ b/apps/editor/lib/dom.ts
@@ -123,7 +123,11 @@ export const drawHighlightsForElementSuggestions = (
   suggestionsCoordinates.forEach((coordinates) => {
     if (
       ctx &&
-      isPointInVisiblePartOfElement(coordinates.left, coordinates.top, target)
+      isPointInVisiblePartOfElement(
+        coordinates.left,
+        coordinates.top + coordinates.height,
+        target
+      )
     ) {
       drawSuggestionRect(ctx, coordinates, targetElRect);
     }


### PR DESCRIPTION
## Description
This PR provides a fix for when the mirror canvas element does not have the same exact height as the content editable element

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Scope of Change
Which part of the monorepo does this PR affect? (Select all that apply)
- [x] Editor App
- [ ] UI package
- [ ] Tailwind package
- [ ] Chrome Extension
- [ ] Other

## Related Issue
Does this pull request address an open issue? If so, please provide the issue number or link.

Closes #[ISSUE_NUMBER]

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

If this PR introduces changes to the UI or Chrome extension, please include screenshots of the changes.

## Checklist:
Please ensure your pull request meets the following criteria:

- [x] I have read the contribution guidelines.
- [x] I have included comments in the code, where necessary.
- [x] My changes follow the project’s coding style.
- [x] I have added new tests to cover the changes (where applicable).
- [x] All new and existing tests passed.
- [x] This PR does not contain any sensitive or personal information.

## Additional Notes
Is there anything else you want the reviewer to know? Any additional context or information should be provided here.
